### PR TITLE
코드 리팩토링

### DIFF
--- a/src/components/CategoryList.js
+++ b/src/components/CategoryList.js
@@ -1,25 +1,32 @@
-import React from 'react'
-import styled from 'styled-components'
+import React, { Component } from 'react'
 import { Menu } from 'semantic-ui-react'
 
-const Wrapper = styled.div`
-  text-align: center;
-`
+export default class CategoryList extends Component {
+  state = {
+    activeItem: this.props.categories[0].name,
+  }
 
-const CategoryList = ({ onCategoryClick, activeItem, categories }) => (
-  <Wrapper>
-    <Menu pointing secondary color="red">
-      {categories.map(category => (
-        <Menu.Item
-          key={category.name}
-          name={category.name}
-          active={activeItem === category.name}
-          onClick={onCategoryClick}
-          {...category.link}
-        />
-      ))}
-    </Menu>
-  </Wrapper>
-)
+  handleCategoryClick = (e, { name }) => {
+    this.setState({ activeItem: name })
+  }
 
-export default CategoryList
+  render() {
+    const { activeItem } = this.state
+    const { categories } = this.props
+    return (
+      <div>
+        <Menu pointing secondary color="red">
+          {categories.map(category => (
+            <Menu.Item
+              key={category.name}
+              name={category.name}
+              active={activeItem === category.name}
+              onClick={this.handleCategoryClick}
+              {...category.link}
+            />
+          ))}
+        </Menu>
+      </div>
+    )
+  }
+}

--- a/src/components/LoginButton.js
+++ b/src/components/LoginButton.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react'
+import React from 'react'
 import { Button, Icon, Segment } from 'semantic-ui-react'
 import styled from 'styled-components'
 

--- a/src/containers/CategoryListContainer.js
+++ b/src/containers/CategoryListContainer.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react'
+import React from 'react'
 import { Link } from 'react-router-dom'
 import { CategoryList } from 'components'
 
@@ -33,21 +33,8 @@ const categories = [
   },
 ]
 
-export default class CategoryListContainer extends Component {
-  state = { activeItem: '전체' }
+const CategoryListContainer = () => (
+  <CategoryList categories={categories} />
+)
 
-  handleCategoryClick = (e, { name }) => {
-    this.setState({ activeItem: name })
-  }
-
-  render() {
-    const { activeItem } = this.state
-    return (
-      <CategoryList
-        onCategoryClick={this.handleCategoryClick}
-        activeItem={activeItem}
-        categories={categories}
-      />
-    )
-  }
-}
+export default CategoryListContainer

--- a/src/ducks/modules/category.js
+++ b/src/ducks/modules/category.js
@@ -48,11 +48,11 @@ export const loadCourseList = category => async (dispatch) => {
   } else {
     const snapshot = await firebase.database().ref('courses').once('value')
     const result = snapshot.val()
-    const categories = {}
-    for (const category of Object.values(result)) {
-      Object.assign(categories, category)
-    }
-    const courses = Object.entries(categories).map(([id, course]) => ({
+    const rawCourses = Object.values(result).reduce((acc, cur) => ({
+      ...acc,
+      ...cur,
+    }), {})
+    const courses = Object.entries(rawCourses).map(([id, course]) => ({
       id,
       ...course,
     }))

--- a/src/pages/CoursePage.js
+++ b/src/pages/CoursePage.js
@@ -1,0 +1,10 @@
+import React from 'react'
+
+const CoursePage = () => (
+  <div>
+    I am CoursePage.
+  </div>
+)
+
+export default CoursePage
+

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,7 +1,9 @@
 import MainPage from './MainPage'
 import LoginPage from './LoginPage'
+import CoursePage from './CoursePage'
 
 export {
   MainPage,
   LoginPage,
+  CoursePage,
 }


### PR DESCRIPTION
1. ducks/modules/category.js의 `loadCourseList` thunk에서 전체 카테고리에 속한 데이터를 병합하기 위해 `for ~ of` + `Object.assign()`을 사용했던 부분을 `Array.prototype.reduce()`로 수정
2. CategoryList의 UI 상태 관련 state가 CategoryListContainer(CC)에 있던 부분을 CategoryList(PC)로 이동
3. LoginButton 컴포넌트에서 불필요 코드 제거